### PR TITLE
Add guided encoding workflow with drag-and-drop support

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,9 +108,9 @@ def get_image_download_link(img_path):
     return href
 
 def main():
-    st.title("STEGOSAURUS WRECKS")
+    st.title("FritzTheCat")
 
-    st.info("🦕S̷̛̤̼̥̹͚͈̓̽̂E̴̳̘͕͍̯̮͖̖͚͋̋͠Ȩ̶͕̪͈̋ͅḎ̴̮͙̯̅̿̈́͐̏ ̷̳̗̟͕͐͂͒̉̑̕T̶̡͖͕̬̺̪̼̂̋̎̾̓͠ͅḪ̷̼͈̝̯̉͆̓̔̒̿̀̈́E̷̝̰͔̺͛̋͌̂̚ ̴̡̡̳̭̹͐̉̈̑F̵̫̜͆́̄͆͑̍́͆͠U̶̪̖̖̻̫͙̓̆̓͜T̵̛͔̭͈̙̙̠̜̤̠̓́́̈̕̕Ȕ̵̜͎̘̞̯͍̦̫͖̆Ŗ̶͍͓̤̪͍̦͔͙̿Ȩ̵͈̹̬͓̝̮̟̎̓͒̀̈́🔮")
+    st.info("😺 ICODETHATIAM 💥")
     uploaded_file = st.file_uploader(
         "Drag and drop base image here",
         type=["png", "jpg", "jpeg"],


### PR DESCRIPTION
## Summary
- Replace manual output path with automatic temporary file handling
- Add progress bar and context tips to encoding steps
- Enable drag-and-drop upload zones for base images and payload files

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a641f99e58832989010a55cf7a16f7