### PR TITLE
Add encryption and cat branding

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,25 @@
 import os
 import base64
 import zlib
+import hashlib
 import streamlit as st
 from PIL import Image
+from cryptography.fernet import Fernet
+
+
+def derive_key(password: str) -> bytes:
+    """Derive a Fernet-compatible key from a password."""
+    return base64.urlsafe_b64encode(hashlib.sha256(password.encode()).digest())
+
+
+def encrypt_data(data: bytes, password: str) -> bytes:
+    """Encrypt bytes with a password."""
+    return Fernet(derive_key(password)).encrypt(data)
+
+
+def decrypt_data(token: bytes, password: str) -> bytes:
+    """Decrypt bytes with a password."""
+    return Fernet(derive_key(password)).decrypt(token)
 
 def convert_to_png(image_path):
     """
@@ -29,10 +46,11 @@ def compress_image_before_encoding(image_path, output_image_path):
         img = img.resize((img.width // 2, img.height // 2))  # Reduce size by half
         img.save(output_image_path, optimize=True, format="PNG")  # Save the compressed image again
 
-def encode_text_into_plane(image, text, output_path, plane="RGB"):
-    """
-    Embed the text into a specific color plane (R, G, B, A).
-    """
+def encode_text_into_plane(image, text, output_path, plane="RGB", password=None):
+    """Embed the text into a specific color plane (R, G, B, A)."""
+    if password:
+        text_bytes = encrypt_data(text.encode(), password)
+        text = base64.b64encode(text_bytes).decode()
     img = image.convert("RGBA")  # Ensure image has alpha channel
     width, height = img.size
     binary_text = ''.join(format(ord(char), '08b') for char in text) + '00000000'  # Add terminator
@@ -62,11 +80,11 @@ def encode_text_into_plane(image, text, output_path, plane="RGB"):
 
     img.save(output_path, format="PNG")
 
-def encode_zlib_into_image(image, file_data, output_path, plane="RGB"):
-    """
-    Embed zlib-compressed binary data into a specific color plane (R, G, B, A).
-    """
+def encode_zlib_into_image(image, file_data, output_path, plane="RGB", password=None):
+    """Embed zlib-compressed binary data into a specific color plane (R, G, B, A)."""
     compressed_data = zlib.compress(file_data)
+    if password:
+        compressed_data = encrypt_data(compressed_data, password)
     binary_data = ''.join(format(byte, '08b') for byte in compressed_data) + '00000000'  # Add terminator
     width, height = image.size
     pixel_capacity = width * height  # Capacity per plane
@@ -96,10 +114,8 @@ def encode_zlib_into_image(image, file_data, output_path, plane="RGB"):
 
     img.save(output_path, format="PNG")
 
-def decode_text_from_plane(image, plane="RGB"):
-    """
-    Extract hidden text from the specified color plane.
-    """
+def decode_text_from_plane(image, plane="RGB", password=None):
+    """Extract hidden text from the specified color plane."""
     img = image.convert("RGBA")
     width, height = img.size
     bits = []
@@ -131,12 +147,17 @@ def decode_text_from_plane(image, plane="RGB"):
     if not found_terminator or not chars:
         raise ValueError("No hidden text found in the image.")
 
-    return ''.join(chars)
+    text = ''.join(chars)
+    if password:
+        try:
+            decrypted = decrypt_data(base64.b64decode(text), password)
+            return decrypted.decode()
+        except Exception:
+            raise ValueError("Failed to decrypt hidden text.")
+    return text
 
-def decode_zlib_from_image(image, plane="RGB"):
-    """
-    Extract and decompress zlib data hidden in a specific color plane.
-    """
+def decode_zlib_from_image(image, plane="RGB", password=None):
+    """Extract and decompress zlib data hidden in a specific color plane."""
     img = image.convert("RGBA")
     width, height = img.size
     bits = []
@@ -168,8 +189,14 @@ def decode_zlib_from_image(image, plane="RGB"):
     if not found_terminator or not data_bytes:
         raise ValueError("No hidden data found in the image.")
 
+    data = bytes(data_bytes)
+    if password:
+        try:
+            data = decrypt_data(data, password)
+        except Exception:
+            raise ValueError("Failed to decrypt hidden data.")
     try:
-        return zlib.decompress(bytes(data_bytes))
+        return zlib.decompress(data)
     except zlib.error:
         raise ValueError("Failed to decompress hidden data.")
 
@@ -184,9 +211,9 @@ def get_image_download_link(img_path):
     return href
 
 def main():
-    st.title("STEGOSAURUS WRECKS")
+    st.title("FritzTheCat")
 
-    st.info("🦕S̷̛̤̼̥̹͚͈̓̽̂E̴̳̘͕͍̯̮͖̖͚͋̋͠Ȩ̶͕̪͈̋ͅḎ̴̮͙̯̅̿̈́͐̏ ̷̳̗̟͕͐͂͒̉̑̕T̶̡͖͕̬̺̪̼̂̋̎̾̓͠ͅḪ̷̼͈̝̯̉͆̓̔̒̿̀̈́E̷̝̰͔̺͛̋͌̂̚ ̴̡̡̳̭̹͐̉̈̑F̵̫̜͆́̄͆͑̍́͆͠U̶̪̖̖̻̫͙̓̆̓͜T̵̛͔̭͈̙̙̠̜̤̠̓́́̈̕̕Ȕ̵̜͎̘̞̯͍̦̫͖̆Ŗ̶͍͓̤̪͍̦͔͙̿Ȩ̵͈̹̬͓̝̮̟̎̓͒̀̈́🔮")
+    st.info("😺 I CODE THAT I AM 💥")
 
     mode = st.radio("Mode", ["Encode", "Decode"])
 
@@ -202,6 +229,7 @@ def main():
     st.markdown("---")
 
     if mode == "Encode":
+        password = st.text_input("Password", type="password")
         # Add a toggle for the Jailbreak prompt
         enable_jailbreak = st.checkbox("Enable Jailbreak Text", help="Toggle this to enable the special jailbreak text for encoding.")
 
@@ -237,33 +265,37 @@ def main():
         output_image_path = st.text_input("Output File Path:", value=default_output_image_path, help="You can edit the output file path here; the default is a prompt injection for ChatGPT.")
 
         if st.button("Encode"):
-            st.info("Processing...")
+            try:
+                st.info("Processing...")
 
-            # Compress the image before encoding to ensure it's under 900 KB
-            compress_image_before_encoding(image_path, output_image_path)
+                # Compress the image before encoding to ensure it's under 900 KB
+                compress_image_before_encoding(image_path, output_image_path)
 
-            # If embedding text
-            if option == "Text" and master_plan:
-                image = Image.open(output_image_path)
-                encode_text_into_plane(image, master_plan, output_image_path, encoding_plane)
-                st.success(f"Text successfully encoded into the {encoding_plane} plane.")
+                # If embedding text
+                if option == "Text" and master_plan:
+                    image = Image.open(output_image_path)
+                    encode_text_into_plane(image, master_plan, output_image_path, encoding_plane, password or None)
+                    st.success(f"Text successfully encoded into the {encoding_plane} plane.")
 
-            # If embedding zlib file
-            elif option == "Zlib Compressed File" and uploaded_file_zlib:
-                file_data = uploaded_file_zlib.read()
-                image = Image.open(output_image_path)
-                encode_zlib_into_image(image, file_data, output_image_path, encoding_plane)
-                st.success(f"Zlib compressed file successfully encoded into the {encoding_plane} plane.")
-            else:
-                st.error("No data provided for encoding.")
+                # If embedding zlib file
+                elif option == "Zlib Compressed File" and uploaded_file_zlib:
+                    file_data = uploaded_file_zlib.read()
+                    image = Image.open(output_image_path)
+                    encode_zlib_into_image(image, file_data, output_image_path, encoding_plane, password or None)
+                    st.success(f"Zlib compressed file successfully encoded into the {encoding_plane} plane.")
+                else:
+                    st.error("No data provided for encoding.")
 
-            st.image(output_image_path, caption="Click the link below to download the encoded image.", use_column_width=True)
-            st.markdown(get_image_download_link(output_image_path), unsafe_allow_html=True)
+                st.image(output_image_path, caption="Click the link below to download the encoded image.", use_column_width=True)
+                st.markdown(get_image_download_link(output_image_path), unsafe_allow_html=True)
 
-            # Add balloons
-            st.balloons()
+                # Add balloons
+                st.balloons()
+            except Exception as e:
+                st.error(str(e))
 
     else:
+        password = st.text_input("Password", type="password")
         decoding_option = st.radio("Select what you want to decode:", ["Text", "Zlib Compressed File"], help="Choose between extracting text or a compressed file from the image.")
         decoding_plane = st.selectbox("Select the color plane for decoding:", ["RGB", "R", "G", "B", "A"], help="Choose which color channels were used for embedding.")
 
@@ -271,11 +303,11 @@ def main():
             image = Image.open(image_path)
             try:
                 if decoding_option == "Text":
-                    extracted_text = decode_text_from_plane(image, decoding_plane)
+                    extracted_text = decode_text_from_plane(image, decoding_plane, password or None)
                     st.success("Hidden text extracted:")
                     st.text_area("Decoded Text:", extracted_text)
                 else:
-                    data = decode_zlib_from_image(image, decoding_plane)
+                    data = decode_zlib_from_image(image, decoding_plane, password or None)
                     st.success("Hidden file extracted.")
                     st.download_button("Download decoded file", data, file_name="decoded.bin")
             except ValueError as e:


### PR DESCRIPTION
## Summary
- add password-based encryption for encoded text and files
- rename UI to FritzTheCat with new info message
- handle encode/decode errors and accept password in UI

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from PIL import Image
import app
img = Image.new('RGBA', (100,100), 'white')
app.encode_text_into_plane(img, 'hello', '/tmp/test.png', 'RGB', password='cat')
img2 = Image.open('/tmp/test.png')
print(app.decode_text_from_plane(img2, 'RGB', password='cat'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a63ff8128083299ff361498f6d8e24