### PR TITLE
Sequential stego channel iteration with tests

### DIFF
--- a/tests/test_app_roundtrip.py
+++ b/tests/test_app_roundtrip.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+from PIL import Image
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import (
+    encode_text_into_plane,
+    decode_text_from_plane,
+    encode_zlib_into_image,
+    decode_zlib_from_image,
+)
+
+
+def test_encode_decode_text_roundtrip(tmp_path):
+    img = Image.new("RGBA", (40, 40), color=(255, 255, 255, 255))
+    message = "sequential channels"
+    out_path = tmp_path / "encoded_text.png"
+
+    paths = encode_text_into_plane(img, message, str(out_path), plane="RGB")
+    images = [Image.open(p) for p in paths]
+    decoded = decode_text_from_plane(images, plane="RGB")
+    assert decoded == message
+
+
+def test_encode_decode_file_roundtrip(tmp_path):
+    img = Image.new("RGBA", (50, 50), color=(255, 255, 255, 255))
+    data = b"binary payload for testing"
+    out_path = tmp_path / "encoded_file.png"
+
+    paths = encode_zlib_into_image(img, data, str(out_path), plane="RGB")
+    images = [Image.open(p) for p in paths]
+    recovered = decode_zlib_from_image(images, plane="RGB")
+    assert recovered == data

--- a/tests/test_stego.py
+++ b/tests/test_stego.py
@@ -1,4 +1,4 @@
- import os
+import os
 import sys
 
 from PIL import Image
@@ -16,4 +16,3 @@ def test_encode_decode_roundtrip(tmp_path):
     out_img = Image.open(out_path)
     decoded = decode_text_from_plane(out_img, plane="RGB", password="secret")
     assert decoded == text
- 


### PR DESCRIPTION
## Summary
- Write payload bits sequentially across selected color channels without wrap-around in encoding
- Read bits in identical sequence during decoding
- Add round-trip tests for text and binary payloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b8d2460c83299caa928b9bcd5b48